### PR TITLE
Add include to limits

### DIFF
--- a/slot_map/slot_map.h
+++ b/slot_map/slot_map.h
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <vector>
 #include <algorithm>
+#include <limits>
 
 
 #include <inttypes.h>


### PR DESCRIPTION
On Linux with g++-11, when building a file that does not include `limits` before `slot_map.h`, we get the following errors. All we need is to add the include in the header file and the errors disappear. 

```
/home/mgaillard/slot_map/slot_map/./slot_map.h: In member function ‘stl::Allocator<T, Alignment>::size_type stl::Allocator<T, Alignment>::max_size() const’:
/home/mgaillard/slot_map/slot_map/./slot_map.h:82:55: error: ‘numeric_limits’ is not a member of ‘std’
   82 |     size_type max_size() const noexcept { return std::numeric_limits<size_type>::max() / sizeof(value_type); }
      |                                                       ^~~~~~~~~~~~~~
/home/mgaillard/slot_map/slot_map/./slot_map.h:82:79: error: expected primary-expression before ‘>’ token
   82 |     size_type max_size() const noexcept { return std::numeric_limits<size_type>::max() / sizeof(value_type); }
      |                                                                               ^
/home/mgaillard/slot_map/slot_map/./slot_map.h:82:82: error: ‘::max’ has not been declared; did you mean ‘std::max’?
   82 |     size_type max_size() const noexcept { return std::numeric_limits<size_type>::max() / sizeof(value_type); }
      |                                                                                  ^~~
      |                                                                                  std::max
In file included from /usr/include/c++/11/functional:65,
                 from /home/mgaillard/slot_map/slot_map/./slot_map.h:5,
                 from /home/mgaillard/slot_map/SlotMapTest01.cpp:1:
/usr/include/c++/11/bits/stl_algo.h:3467:5: note: ‘std::max’ declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
```